### PR TITLE
Better runner

### DIFF
--- a/src/main/java/org/sar/ppi/Ppi.java
+++ b/src/main/java/org/sar/ppi/Ppi.java
@@ -1,15 +1,13 @@
 package org.sar.ppi;
 
-import java.util.Arrays;
-
 /**
  * Ppi
  */
 public class Ppi {
 
 	/**
-	 * The main to call to run the app.
-	 * Usage: {@code java org.sar.Ppi <process-class-name> <runner-class-name> [<nb-proc>]}
+	 * The main to call to run the app. Usage:
+	 * {@code java org.sar.Ppi <process-class-name> <runner-class-name> [<nb-proc> [<scenario>]]}
 	 *
 	 * This function sets the defaults values, then call the Runner's init method
 	 * which should then call Ppi.main().
@@ -18,24 +16,53 @@ public class Ppi {
 	 * @throws PpiException on every internal error (TODO more Exceptions)
 	 */
 	public static void main(String[] args) throws PpiException {
+		Class<? extends NodeProcess> processClass;
+		Runner runner;
+		int nbProcs = 5;
+		String scenario = null;
+
+		if (args.length < 2 || args.length > 4) {
+			System.out.println("Usage: ppirun <process-class-name> <runner-class-name> [<nb-proc> [<scenario>]]");
+			return;
+		}
+		try {
+			processClass = Class.forName(args[0]).asSubclass(NodeProcess.class);
+		} catch (ClassNotFoundException e) {
+			throw new PpiException("Could not find the process class " + args[0], e);
+		}
 		try {
 			Class<? extends Runner> rClass = Class.forName(args[1]).asSubclass(Runner.class);
-			args = Arrays.copyOf(args, 4);
-			if (args[2] == null) {
-				args[2] = "5";
-			}
-			rClass.newInstance().init(args);
+			runner = rClass.newInstance();
 		} catch (ReflectiveOperationException e) {
-			throw new PpiException("Failed to init the process", e);
+			throw new PpiException("Failed to intanciate the Runner", e);
 		}
+		if (args.length >= 3) {
+			try {
+				nbProcs = new Integer(args[2]);
+			} catch (NumberFormatException e) {
+				throw new PpiException("Not a valid number for <nb-proc> param", e);
+			}
+		}
+		if (args.length >= 4) {
+			scenario = args[3];
+		}
+		main(processClass, runner, nbProcs, scenario);
 	}
 
-	public static void run(String[] args, Runner runner) throws PpiException {
+	/**
+	 * Higher level main for easier from java invocations.
+	 * @param pClass the class to execute by Ppi.
+	 * @param runner the runner to use for this execution.
+	 * @param nbProcs the number of processes to run.
+	 * @param scenario the name of the scenario file.
+	 * @throws PpiException if pClass instanciation fails.
+	 */
+	public static void main(Class<? extends NodeProcess> pClass, Runner runner, int nbProcs, String scenario)
+			throws PpiException {
 		try {
-			Class<? extends NodeProcess> pClass = Class.forName(args[0]).asSubclass(NodeProcess.class);
-			runner.run(pClass, args);
+			runner.run(pClass, nbProcs, scenario);
 		} catch (ReflectiveOperationException e) {
-			throw new PpiException("Failed to run the process", e);
+			throw new PpiException("Failed to intantiate the process class " + pClass.getName(), e);
 		}
 	}
 

--- a/src/main/java/org/sar/ppi/Runner.java
+++ b/src/main/java/org/sar/ppi/Runner.java
@@ -6,22 +6,11 @@ package org.sar.ppi;
 public interface Runner {
 
 	/**
-	 * The init sequence for this Runner.
-	 * If nothing needs to be prepared before the run method, then the default
-	 * implementation can be left as it is.
-	 *
-	 * @param args the cli args.
+	 * Run the runner.
+	 * @param pClass the class to execute by Ppi.
+	 * @param nbProcs the number of processes to run.
+	 * @param scenario the name of the scenario file.
+	 * @throws ReflectiveOperationException if pClass instanciation fails.
 	 */
-	default public void init(String[] args) throws PpiException {
-		Ppi.run(args, this);
-	}
-
-	/**
-	 * 
-	 * @param processClass the user extension of NodeProcess
-	 * @param args cli arguments
-	 * @throws ReflectiveOperationException if processClass instanciation fails
-	 */
-	public void run(Class<? extends NodeProcess> processClass, String[] args)
-			throws ReflectiveOperationException;
+	public void run(Class<? extends NodeProcess> pClass, int nbProcs, String scenario) throws ReflectiveOperationException;
 }

--- a/src/main/java/org/sar/ppi/mpi/MpiRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiRunner.java
@@ -14,17 +14,19 @@ import org.sar.ppi.Runner;
  */
 public class MpiRunner implements Runner {
 
-	public static void main(String[] args) {
-		Ppi.run(args, new MpiRunner());
-	}
-
 	@Override
-	public void init(String[] args) throws PpiException {
+	public void run(Class<? extends NodeProcess> pClass, int nbProcs, String scenario) throws PpiException {
 		String s = null;
 		boolean err = false;
 		String cmd = String.format(
-			"mpirun --oversubscribe --np %s java -cp %s %s %s",
-			args[2], System.getProperty("java.class.path"), this.getClass().getName(), args[0]);
+			"mpirun --oversubscribe --np %s java -cp %s %s %s %s %d %s",
+			nbProcs,
+			System.getProperty("java.class.path"),
+			Ppi.class.getName(), pClass.getName(),
+			MpiSubRunner.class.getName(),
+			nbProcs,
+			scenario
+		);
 		try {
 			Process p = Runtime.getRuntime().exec(cmd);
 			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -51,15 +53,5 @@ public class MpiRunner implements Runner {
 		if (err) {
 			throw new PpiException("An error occured with Mpi");
 		}
-	}
-
-	@Override
-	public void run(Class<? extends NodeProcess> processClass, String[] options)
-			throws ReflectiveOperationException {
-		NodeProcess process = processClass.newInstance();
-		MpiInfrastructure infra = new MpiInfrastructure(process);
-		process.setInfra(infra);
-		infra.run(options);
-		infra.exit();
 	}
 }

--- a/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
@@ -1,0 +1,17 @@
+package org.sar.ppi.mpi;
+
+import org.sar.ppi.NodeProcess;
+import org.sar.ppi.Runner;
+
+public class MpiSubRunner implements Runner {
+
+	@Override
+	public void run(Class<? extends NodeProcess> pClass, int nbProcs, String scenario)
+			throws ReflectiveOperationException {
+		NodeProcess process = pClass.newInstance();
+		MpiInfrastructure infra = new MpiInfrastructure(process);
+		process.setInfra(infra);
+		infra.run(new String[0]);
+		infra.exit();
+	}
+}

--- a/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
@@ -18,7 +18,7 @@ import peersim.Simulator;
 public class PeerSimRunner implements Runner {
 
 	@Override
-	public void run(Class<? extends NodeProcess> processClass, String[] args)
+	public void run(Class<? extends NodeProcess> pClass, int nbProcs, String scenario)
 			throws ReflectiveOperationException {
 		String tmpdir = System.getProperty("java.io.tmpdir");
 		String tmpfile = Paths.get(tmpdir, "ppi-peersim.config").toString();
@@ -29,8 +29,8 @@ public class PeerSimRunner implements Runner {
 			Path base = Paths.get(loader.getResource("peersim.base.conf").toURI());
 			Files.copy(base, os);
 			ps.println();
-			ps.println("protocol.infra.nodeprocess " + processClass.getName());
-			ps.println("network.size " + args[2]);
+			ps.println("protocol.infra.nodeprocess " + pClass.getName());
+			ps.printf("network.size %d\n", nbProcs);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/sar/ppi/simulator/peersim/PeerSimRunSimulation.java
+++ b/src/main/java/org/sar/ppi/simulator/peersim/PeerSimRunSimulation.java
@@ -14,9 +14,9 @@ import java.nio.file.Paths;
 
 public class PeerSimRunSimulation implements Runner {
     @Override
-    public void run(Class<? extends NodeProcess> processClass, String[] args) {
-        if(args.length<4)
-            throw new PpiException("Moore args are needed <Name Class Protocol> <Name Class Runner> <nb process> <Path to the file .json>");
+    public void run(Class<? extends NodeProcess> pClass, int nbProcs, String scenario) {
+        if (scenario == null)
+            throw new PpiException("<scenario> parameter is needed for this Runner");
 
         String tmpdir = System.getProperty("java.io.tmpdir");
         String tmpfile = Paths.get(tmpdir, "ppi-peersim.config").toString();
@@ -27,9 +27,9 @@ public class PeerSimRunSimulation implements Runner {
             Path base = Paths.get(loader.getResource("peersimSimulate.base.conf").toURI());
             Files.copy(base, os);
             ps.println();
-            ps.println("protocol.infra.nodeprocess " + processClass.getName());
-            ps.println("network.size " + args[2]);
-            ps.println("path "+args[3]);
+            ps.println("protocol.infra.nodeprocess " + pClass.getName());
+            ps.printf("network.size %d\n", nbProcs);
+            ps.println("path " + scenario);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Surtout en ajoutant le MpiSubRunner qui permet de supprimer l'aller retour du Runner à Ppi. ça concerne surtout @Atlaoui .

En gros le tricks c'est que `MpiRunner` au lieu de s'appeler lui même comme main il appelle a nouveau `Ppi` mais cette fois en lui passant comme runner le `MpiRubRunner`. Je trouve ça beaucoup plus propre comme manière de faire.

ça ajoute aussi un `main` de plus haut niveau quand on appelle `Ppi` depuis java pour ne pas avoir à construire un tableau de char à la con.

Closes #36 