### PR TITLE
Packaging de ppi en un simple .jar self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ public class ExampleNodeProcess extends NodeProcess {
 }
 ```
 
+Then you can compile your class and run it with the bundled jar which will
+dynamically load it:
+
+```bash
+javac -cp ppi-0.2-dev-bundle.jar ExampleNodeProcess
+java -jar ppi-0.2-dev-bundle.jar ExampleNodeProcess org.sar.ppi.peersim.PeerSimRunner 4
+```
+
+Alternatively you can call `Ppi.main()` yourself like this and the run your class:
+
+```java
+public static void main(String[] args) {
+	Ppi.main(ExampleNodeProcess.class, new MpiRunner(), 4, null);
+}
+```
+
+```bash
+javac -cp ppi-0.2-dev-bundle.jar ExampleNodeProcess
+java -cp .:ppi-0.2-dev-bundle.jar ExampleNodeProcess
+```
+
 ### API reference
 
 The API consists of the [public methods of the `Infrastructure` class](https://atlaoui.github.io/ParallelProgramingInterface/org/sar/ppi/Infrastructure.html)
@@ -99,6 +120,10 @@ If you installed the libraries in a different location you can use the options
 ## Run tests
 
     mvn test
+
+## Build executable jar
+
+    mvn package
 
 ## Docs
 

--- a/assembly.xml
+++ b/assembly.xml
@@ -1,0 +1,20 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>bundle</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <unpack>true</unpack>
+      <scope>system</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.sar.ppi</groupId>
@@ -96,6 +95,30 @@
           <!-- <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile> -->
           <show>public</show>
         </configuration>
+      </plugin>
+      <!-- Create an executable .jar -->
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.sar.ppi.Ppi</mainClass>
+            </manifest>
+          </archive>
+          <descriptors>
+            <descriptor>${basedir}/assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id> <!-- this is used for inheritance merges -->
+            <phase>package</phase> <!-- bind to the packaging phase -->
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.sar.ppi</groupId>
   <artifactId>ppi</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>0.2-dev</version>
 
   <name>ppi</name>
   <url>https://github.com/Atlaoui/ParallelProgramingInterface</url>

--- a/src/main/java/org/sar/ppi/Ppi.java
+++ b/src/main/java/org/sar/ppi/Ppi.java
@@ -1,5 +1,11 @@
 package org.sar.ppi;
 
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import java.io.File;
+import java.io.IOException;
+
 /**
  * Ppi Main class.
  */
@@ -25,10 +31,18 @@ public class Ppi {
 			System.out.println("Usage: ppirun <process-class-name> <runner-class-name> [<nb-proc> [<scenario>]]");
 			return;
 		}
+		String pClassName = args[0];
 		try {
-			processClass = Class.forName(args[0]).asSubclass(NodeProcess.class);
+			processClass = Class.forName(pClassName).asSubclass(NodeProcess.class);
 		} catch (ClassNotFoundException e) {
-			throw new PpiException("Could not find the process class " + args[0], e);
+			try (URLClassLoader loader = new URLClassLoader(new URL[] { new File(System.getProperty("user.dir")).toURI().toURL() })) {
+				processClass = loader.loadClass(pClassName).asSubclass(NodeProcess.class);
+				loader.close();
+			} catch (ClassCastException | ClassNotFoundException | IOException t) {
+				throw new PpiException("Could not find the process class " + args[0], t);
+			}
+		} catch (ClassCastException e) {
+			throw new PpiException("The class " + pClassName + " does not extend NodeProcess", e);
 		}
 		try {
 			Class<? extends Runner> rClass = Class.forName(args[1]).asSubclass(Runner.class);

--- a/src/main/java/org/sar/ppi/Ppi.java
+++ b/src/main/java/org/sar/ppi/Ppi.java
@@ -10,6 +10,8 @@ import java.io.IOException;
  * Ppi Main class.
  */
 public class Ppi {
+	
+	public static ClassLoader loader = ClassLoader.getSystemClassLoader();
 
 	/**
 	 * The main to call to run the app. Usage:
@@ -35,9 +37,9 @@ public class Ppi {
 		try {
 			processClass = Class.forName(pClassName).asSubclass(NodeProcess.class);
 		} catch (ClassNotFoundException e) {
-			try (URLClassLoader loader = new URLClassLoader(new URL[] { new File(System.getProperty("user.dir")).toURI().toURL() })) {
+			try {
+				loader = new URLClassLoader(new URL[] { new File(System.getProperty("user.dir")).toURI().toURL() }, loader);
 				processClass = loader.loadClass(pClassName).asSubclass(NodeProcess.class);
-				loader.close();
 			} catch (ClassCastException | ClassNotFoundException | IOException t) {
 				throw new PpiException("Could not find the process class " + args[0], t);
 			}

--- a/src/main/java/org/sar/ppi/Utils.java
+++ b/src/main/java/org/sar/ppi/Utils.java
@@ -1,0 +1,16 @@
+package org.sar.ppi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class Utils {
+	public static void transferTo(InputStream in, OutputStream out) throws IOException {
+		int length;
+		byte[] bytes = new byte[1024];
+		// copy data from input stream to output stream
+		while ((length = in.read(bytes)) != -1) {
+			out.write(bytes, 0, length);
+		}
+	}
+}

--- a/src/main/java/org/sar/ppi/peersim/PeerSimInfrastructure.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimInfrastructure.java
@@ -38,7 +38,7 @@ public class PeerSimInfrastructure extends Infrastructure implements EDProtocol 
 		super(null);
 		NodeProcess np=null;
 		try {
-			np = (NodeProcess) Class.forName(Configuration.getString(prefix+"."+PAR_NP)).getConstructor().newInstance();
+			np = (NodeProcess) Ppi.loader.loadClass(Configuration.getString(prefix+"."+PAR_NP)).getConstructor().newInstance();
 			np.setInfra(this);
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
 				| NoSuchMethodException | SecurityException | ClassNotFoundException e) {

--- a/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
@@ -1,14 +1,14 @@
 package org.sar.ppi.peersim;
 
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Runner;
+import org.sar.ppi.Utils;
 
 import peersim.Simulator;
 
@@ -27,8 +27,8 @@ public class PeerSimRunner implements Runner {
 			 PrintStream ps = new PrintStream(os))
 		{
 			ClassLoader loader = Thread.currentThread().getContextClassLoader();
-			Path base = Paths.get(loader.getResource("peersim.base.conf").toURI());
-			Files.copy(base, os);
+			InputStream base = loader.getResourceAsStream("peersim.base.conf");
+			Utils.transferTo(base, os);
 			ps.println();
 			ps.println("protocol.infra.nodeprocess " + pClass.getName());
 			ps.printf("network.size %d\n", nbProcs);

--- a/src/main/java/org/sar/ppi/simulator/peersim/PeerSimRunSimulation.java
+++ b/src/main/java/org/sar/ppi/simulator/peersim/PeerSimRunSimulation.java
@@ -3,13 +3,14 @@ package org.sar.ppi.simulator.peersim;
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.PpiException;
 import org.sar.ppi.Runner;
+import org.sar.ppi.Utils;
+
 import peersim.Simulator;
 
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -28,8 +29,8 @@ public class PeerSimRunSimulation implements Runner {
              PrintStream ps = new PrintStream(os))
         {
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
-            Path base = Paths.get(loader.getResource("peersimSimulate.base.conf").toURI());
-            Files.copy(base, os);
+            InputStream base = loader.getResourceAsStream("peersimSimulate.base.conf");
+            Utils.transferTo(base, os);
             ps.println();
             ps.println("protocol.infra.nodeprocess " + pClass.getName());
             ps.printf("network.size %d\n", nbProcs);


### PR DESCRIPTION
Comprends #37.

Sans ça le projet n'est pas vraiment utilisable en l'état. Les dépendances sont incluses et les NodeProcessExtensions sont dynamiquement loadés pour ne pas avoir à jouer du `--classpath`.

Avec ces commits il est maintenant possible d'executer ppi de cette manière:
```
java -jar ppi-0.2-dev-bundle.jar ExampleNodeProcess org.sar.ppi.peersim.PeerSimRunner 4
```

tout en ayant bien sûr auparavant packagé l'application et compilé la classe:
```
mvn package
javac --classpath ppi-0.2-dev-bundle.jar ExampleNodeProcess
```
